### PR TITLE
Fixed checkslickness

### DIFF
--- a/raw-mm.dict.lua
+++ b/raw-mm.dict.lua
@@ -17983,7 +17983,7 @@ dict = {
       end,
 
       onstart = function ()
-        send("apply liniment checkslickness", conf.commandecho)
+        send("apply liniment", conf.commandecho)
       end
     },
     aff = {


### PR DESCRIPTION
Removed 'checkslickness' from 'apply liniment checkslickness' because
the game stopped accepting that as a command, making it fail.

This is a big mistake, makes warrior combat much harder to cure, especially in combination with illusionist
