### PR TITLE
Add scripts needed to automate tests and releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: c
+sudo: required
+install:
+- sudo apt-get update
+- sudo apt-get install lua5.1 luarocks p7zip-full python-sphinx
+- sudo luarocks install penlight
+- gem install github_changelog_generator
+script:
+- bash travis.sh
+notifications:
+  email:
+    on_failure: always
+    on_success: change
+env:
+  global:
+  - GH_REF=github.com/m-mf/m-mf.git
+  - GH_USER=m-mf-machine-account
+  - secure: nuoaPEXRUTlMK99Vy3tN7KgT/eas98nER0Tdx+mt86q/AhSfL4UhnKa6dJfDUkec/tExRgU/gEU44LUx3pWmduJuZZqi+mluwHBPqFFmUdcjf1agV2wvJblJCfEH6OvE61bFQYkn5bROma6NSESJkMPDCmTSmpqaYbUu3sLoE+SBsGEx/zKxHYBmw5/QoVXq6NA9GG5oGrMzt5zpcSwwenccPXMmODQcHXhAR8pakOCNxQJoKq18X1EqX5bANMfVjMajBv0LecliSwuqLU4uyM9swtYZoJmTZZox+2ViHP7uP0n0VekS1jamcarZ4paxBY7BPYB2BHuvv9Nx6L5mf3a7lw1HcFL4GKmCL8tQwRDvQZsKAwig5zEm2IMYyq+s+LITCQvh07j4OzTQx6/J03s0CYNRUzBJjjM6y5dqZJFzWKj3wkcXTCztqN+HpnESqIILnZDEp+TuMV3IJG4xRMbST+CatnHUeJfYrF88xaJdhQBQcgtbxLU5P3CB0JlLakgp9/B2rYxtPdQlcwgYxHFU4UFGrzPRDuw30xTS3LmCNPZQFZ6WzO3rFZUIrSCgd4WnVdYP7MaEXnJmQOTYFIuSU+LOzwen/ZBt5qLX64R7ElVUxvGoqRKAKy1e1P3CGRW6hxSjjO6z2dzG/c5qUtRwhwRSVRrfIPG3w01wjWI=
+deploy:
+  provider: releases
+  file_glob: true
+  file: output/*.zip
+  skip_cleanup: true
+  on:
+    tags: true
+  api_key:
+    secure: BF4Bcrvy/Itxd/ENeE1IrFS7PcqGCVvWduu7hXp44GGjWxYCIwup2YLcDBxFURweSG+bJkcyKJteDt4Yo5QhyHUhXeCKp3uN0HHaa25OJEeW3cauXZ7EEk/jNZOAODPG5lh5Qk5z3hM+Zp3XdANgCNyT5rAu7uCu0WvTvk3RE9FDU5rVLIpOwIvFuAE73R1vVoJF3FMBT5eJJzI8ttFrsxRuul6EaA/ZzijpJuoKF2vuGujSqxuIJQPkWw1iOc2gjQ6JDvNiWClo1kQNt9e3vK2cW5vwtu10aAqGR0gHlSq1qYvYIKO9bXnh682Fh67NbsumJBVTzXZlwQKEcq9cZqSnGPvp+Pa5r/A0tAICirYojgBKMsOKWUSqSjJv3ZtqhMeH42RYymIV5zaXKxf32H9kJca8Bjz7kfO0rogsdbLaZ49x65YtMcq4mwPMcjryAE9sdL0fn+cpIQHheuSWFwSyUgjkY4OjVGsRyryfQNcTNnjbTSr6XTSCPB9PapWNT1oTYLLLKFJ40codVBP616klSkK5dHi9to/r/4hepfhzhIAji02Hlmz+dr3Gn/vngnGGwTwjlFHkzqWNQPD3ZzdXiUWYFOxQVaOhvDHwv199nhQCN6vtElePbzK5hOx5yKEWLwQ3XP1xVglheO34J3TGWzrOPjBIX5yQbfiv5vk=

--- a/generate.lua
+++ b/generate.lua
@@ -21,7 +21,7 @@ local cwd = lfs.currentdir()
 
 local args = lapp [[
 -d,--debug  Build with debugging information enabled
--r,--release  Build all systems
+-r,--release (default false) Build all systems
 -o,--own  Build an m&mf for yourself
  <name> (default me )  Name to build a system for
 ]]
@@ -38,8 +38,8 @@ local args = lapp [[
 
 local name    = args.name
 local release = not args.debug
-local version = "5"
-local doall   = args.release
+local version = args.release
+local doall   = args.release ~= "false"
 local own     = args.own
 local defaultaddons = {
   "peopletracker", "demesne", "namedb", "harvester", "healing", "influencer", "plsorter",
@@ -86,7 +86,7 @@ function os.capture(cmd, raw)
   return s
 end
 
-local function dowork(systemfor, release)
+local function dowork(systemfor, release, own)
   systemfor = stringx.title(systemfor)
 
   local tbl = {}
@@ -242,7 +242,7 @@ if doall then
     if not s then print(m) return end
   end
 else
-  local s,m = pcall(dowork, name, release)
+  local s,m = pcall(dowork, name, release, own)
   if not s then print(m) end
 end
 

--- a/precommit.lua
+++ b/precommit.lua
@@ -10,27 +10,26 @@
 
 -- docs
 -- update version in doc
-sassert(io.input("/home/vadi/Games/Mudlet/mm/generate.lua"))
-t = io.read("*all")
-systemversion = string.match(t, [[version = "(.-)"]])
+local args = {...}
+local systemversion = args[1]
 
-io.input("/home/vadi/Games/Mudlet/mm/doc/conf.py")
+io.input("doc/conf.py")
 t = io.read("*all")
 t = string.gsub(t, [[version = '.-']], string.format("version = '%s'", systemversion))
 t = string.gsub(t, [[release = '.-']], string.format("release = '%s'", systemversion))
-io.output("/home/vadi/Games/Mudlet/mm/doc/conf.py")
+io.output("doc/conf.py")
 io.write(t)
 
 -- regen docs
-os.execute([[cd ~/Games/Mudlet/mm/doc && sphinx-build -j 4 -b html -d _build/doctrees   . _build/html]])
+os.execute([[cd doc && sphinx-build -b html -d _build/doctrees   . _build/html]])
 
 -- update ndb cache listing
-package.path = package.path .. ";doc/?.lua"
+package.path = package.path .. ";./doc/?.lua"
 gl     = require"parse_glossary"
 pretty = require"pl.pretty"
 
 local data = gl.striptrailinglines(gl.readfile("doc/namedb.rst"))
 
-local f = io.open([[/home/vadi/Games/Mudlet/m&m template/ndb-help.lua]], "w+")
+local f = io.open([[m&m template/ndb-help.lua]], "w+")
 f:write(pretty.write(data))
 f:close()

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,63 @@
+lua generate.lua -r "$TRAVIS_TAG"
+
+if [ -z "$TRAVIS_TAG" ]
+then
+  echo "No tag, no update in documentation needed."
+  exit 0
+fi
+
+lua precommit.lua "$TRAVIS_TAG"
+
+cd doc/_build/html
+touch .nojekyll
+
+git init
+
+git config user.name "m-mf-machine-account"
+git config user.email "machine@m-mf.com"
+
+git add .
+git commit -m "Deploy to GitHub Pages"
+
+# Force push from the current repo's master branch to the remote
+# repo's gh-pages branch. (All previous history on the gh-pages branch
+# will be lost, since we are overwriting it.) We redirect any output to
+# /dev/null to hide any sensitive credential data that might otherwise be exposed.
+git push --force --quiet "https://${GH_USER}:${GH_TOKEN}@${GH_REF}" master:gh-pages > /dev/null 1>&2
+
+# create release body
+
+# get all releases first
+http_code=`curl -s -w "%{http_code}" -o output.txt "https://api.github.com/repos/m-mf/m-mf/releases?access_token=${GH_TOKEN}"`
+out=$?
+if [ "$out" != "0" ]
+then
+  echo "Getting releases failed:" "$out"
+  exit 1
+fi
+if [ "$http_code" != "200" ]
+then
+  echo "Getting releases failed:" "$http_code"
+  exit 1
+fi
+
+
+# now generate changelog
+github_changelog_generator --since-tag `cat output.txt | jq '.[1].tag_name | tonumber'` -t ${GH_TOKEN} --no-unreleased --no-issues
+
+# modify the changelog a little
+echo "`cat CHANGELOG.md | grep -v "# Change Log" | grep -v "^##" | egrep -v "This Change Log"`" > CHANGELOG.md
+
+# now upload the changelog
+data=$(jq -n --arg v "`cat CHANGELOG.md`" '{"body": $v}')
+http_code=curl -s -w "%{http_code}" --request PATCH --data "data" "https://api.github.com/repos/m-mf/m-mf/releases/`cat output.txt | jq ".[0].id | tonumber"`?access_token=${GH_TOKEN}"
+if [ "$out" != "0" ]
+then
+  echo "Updating release body failed:" "$out"
+  exit 1
+fi
+if [ "$http_code" != "200" ]
+then
+  echo "Updating release body failed:" "$http_code"
+  exit 1
+fi


### PR DESCRIPTION
I'm the current maintainer of the m-mf sister system svof. A while ago I created an infrastructure to automate release creation and compile checks on PRs. @vadi2 asked me to do the same for m-mf.

This PR adds the needed scripts and files to m-mf. Tests and releases will not work yet though.

The second part will be setting up travis for compiling, documentation and release creation. For that I created a pseudo user @m-mf-machine-account, which will need to be part of the m-mf organisation and in a team with write permissions to the m-mf repository to push documentation. For setup it would also make things easier if it temporarily had admin permissions, so I can create the travis integration and other things without having to ask all the time.
