### PR TITLE
mminstall fix for skill: contort.

### DIFF
--- a/raw-mm.install.lua
+++ b/raw-mm.install.lua
@@ -448,7 +448,7 @@ local installdata = {
       ]]
     },
     no = {
-      pattern = [[^The contortion ability in the Acrobatics skill is unknown to you\.$]],
+      pattern = [[^I know of no skill called "Contort\."$]],
       script = [[
         mm.installclear("contort")
         mm.conf.contort = false


### PR DESCRIPTION
a few years ago the admin in their wisdom decided to allow players to see any skill with the syntax AB ACROBATICS CONTORT. This breaks MMINSTALL which relied on not seeing skills when issuing AB ACROBATICS CONTORT. 

This patch omits the 'skill' in 'ab <skill> <ability> which if not possed will return 'I know of no skill called "x."

This will be one of several small fixes to MMINSTALL before bigger issues are tackled.