### PR TITLE
mminstall removed blind herb option.

### DIFF
--- a/raw-mm.aliases.lua
+++ b/raw-mm.aliases.lua
@@ -338,7 +338,7 @@ local c4,s4 =
 
   cecho(string.format("    <a_blue>- <a_grey>Assuming <a_cyan>%s%% <a_grey>of stats under blackout/recklessness.\n", tostring(conf.assumestats)))
 
-  cecho(string.format("    <a_blue>- <a_grey>Curing blindness with <a_darkgrey>%s<a_grey> and deafness with <a_darkgrey>%s<a_grey>.\n", conf.blindherb, conf.deafherb))
+  cecho(string.format("    <a_blue>- <a_grey>Curing blindness with <a_darkgrey>dust<a_grey> and deafness with <a_darkgrey>%s<a_grey>.\n", conf.deafherb))
 
   cecho(string.format("    <a_blue>- <a_grey>Won't use mana skills below <a_cyan>%s%%<a_grey> mana.\n", tostring(conf.manause)))
 #if skills.shamanism then

--- a/raw-mm.config.lua
+++ b/raw-mm.config.lua
@@ -887,22 +887,6 @@ config_dict = pl.OrderedMap {
     installstart = function () conf.preclot = true end,
     installcheck = function () echof("Should the system do preclotting? Doing so will save you from some bleeding damage, at the cost of more willpower.") end
   }},
-#conf_name = "blindherb"
-  {$(conf_name) = {
-    type = "string",
-    check = function (what)
-      if contains({"faeleaf", "myrtle"}, what:lower()) then return true end
-    end,
-    onset = function ()
-      conf.blindherb = string.lower(conf.blindherb)
-      dict.blind.herb.eatcure = conf.blindherb
-      echof("Okay, will use %s to cure blindness.", conf.blindherb)
-
-    end,
-    installstart = function ()
-      conf.blindherb = nil end,
-    installcheck = function () echof("Which herb do you want to use to cure blindness? Select from faeleaf or myrtle.") end
-  }},
 #conf_name = "deafherb"
   {$(conf_name) = {
     type = "string",


### PR DESCRIPTION
Removed blind herb option from MMINSTALL as there is no longer herb cures for blindness curing.

Left notitification in mmconfig as it is tied to deafness curing and that line should only be removed when defessness herb curing is removed from MMINSTALL.

Left mm.conf.blindherb config-ed to "faeleaf" since there may be legacy bits expecting "faeleaf" or "myrtle". Those bits should be removed when it is no longer clear they are needed.