### PR TITLE
mminstall removal of deaf herb option

### DIFF
--- a/m&m (import me).xml
+++ b/m&m (import me).xml
@@ -27755,8 +27755,10 @@ end</script>
 						<colorTriggerBgColor>#000000</colorTriggerBgColor>
 						<regexCodeList>
 							<string>You now possess the gift of the sixth sense.</string>
+							<string>You now possess the gift of the sixthsense.</string>
 						</regexCodeList>
 						<regexCodePropertyList>
+							<integer>3</integer>
 							<integer>3</integer>
 						</regexCodePropertyList>
 					</Trigger>

--- a/raw-mm.aliases.lua
+++ b/raw-mm.aliases.lua
@@ -338,8 +338,6 @@ local c4,s4 =
 
   cecho(string.format("    <a_blue>- <a_grey>Assuming <a_cyan>%s%% <a_grey>of stats under blackout/recklessness.\n", tostring(conf.assumestats)))
 
-  cecho(string.format("    <a_blue>- <a_grey>Curing blindness with <a_darkgrey>dust<a_grey> and deafness with <a_darkgrey>%s<a_grey>.\n", conf.deafherb))
-
   cecho(string.format("    <a_blue>- <a_grey>Won't use mana skills below <a_cyan>%s%%<a_grey> mana.\n", tostring(conf.manause)))
 #if skills.shamanism then
   cecho(string.format("    <a_blue>- <a_grey>Will make use of sheatheclaw when bleeding over <a_cyan>%s<a_grey> health.\n", tostring(conf.clawamount)))

--- a/raw-mm.config.lua
+++ b/raw-mm.config.lua
@@ -887,22 +887,6 @@ config_dict = pl.OrderedMap {
     installstart = function () conf.preclot = true end,
     installcheck = function () echof("Should the system do preclotting? Doing so will save you from some bleeding damage, at the cost of more willpower.") end
   }},
-#conf_name = "deafherb"
-  {$(conf_name) = {
-    type = "string",
-    check = function (what)
-      if contains({"earwort", "myrtle"}, what:lower()) then return true end
-    end,
-    onset = function ()
-      conf.deafherb = string.lower(conf.deafherb)
-      dict.deaf.herb.eatcure = conf.deafherb
-      echof("Okay, will use %s to cure deafness.", conf.deafherb)
-
-    end,
-    installstart = function ()
-      conf.deafherb = nil end,
-    installcheck = function () echof("Which herb do you want to use to cure deafness? Select from earwort or myrtle.") end
-  }},
 #conf_name = "org"
   {$(conf_name) = {
     type = "string",

--- a/raw-mm.setup.lua
+++ b/raw-mm.setup.lua
@@ -298,7 +298,7 @@ conf.blockcommands = true
 conf.commandechotype = "fancy"
 conf.warningtype = "all"
 conf.blindherb = "faeleaf"
-conf.deafherb = "myrtle"
+conf.deafherb = "faeleaf"
 
 conf.autoreject = "white"
 conf.doubledo = false


### PR DESCRIPTION
also removes the line under mmconfig2 for displaying blind/deaf herb cure.