### PR TITLE
Fix for mm.inamodule to set to false on ship blowing up.

### DIFF
--- a/m&m (import me).xml
+++ b/m&m (import me).xml
@@ -26083,9 +26083,11 @@ raiseEvent("m&amp;m left module")</script>
 						<colorTriggerBgColor>#000000</colorTriggerBgColor>
 						<regexCodeList>
 							<string>With a long, slow blink, you allow your mind to drift free from the ship, and release your lock on</string>
+							<string>You are not standing in a ship.</string>
 						</regexCodeList>
 						<regexCodePropertyList>
 							<integer>2</integer>
+							<integer>3</integer>
 						</regexCodePropertyList>
 					</Trigger>
 				</TriggerGroup>


### PR DESCRIPTION
Sometimes you get removed from a module without unlocking. This should update var mm.inamodule when you send an aethercombat command while not aboard a ship.

Does not fix crashes where you stay inside a ship.

Does not fix logging out and then in.

Last two probably are better addressed in non-mm custom scripts (since to do it here probably means setting mm.inamodule to false and that is not something the casual coder is likely to understand).